### PR TITLE
Allow custom management of the collectd service

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -6,6 +6,7 @@ class collectd (
     $signalfx_api_token,
     $ensure_signalfx_collectd_version         = present,
     $signalfx_collectd_repo_source            = $collectd::params::signalfx_collectd_repo_source,
+    $manage_service                           = $collectd::params::manage_service,
     # collectd.conf parameters
     $fqdnlookup                               = $collectd::params::fqdnlookup,
     $hostname                                 = $collectd::params::hostname,

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -20,6 +20,7 @@ class collectd::params {
         $aws_integration           = true
         $write_http_log_http_error = true
         $write_http_flush_interval = 10
+        $manage_service            = true
 
         $signalfx_plugin_log_traces               = true
         $signalfx_plugin_interactive              = false

--- a/manifests/service.pp
+++ b/manifests/service.pp
@@ -1,7 +1,13 @@
 # private
 class collectd::service {
-  service { 'collectd':
-      ensure  => running,
-      require => Package['collectd']
+
+  if $collectd::manage_service {
+
+    service { 'collectd':
+        ensure  => running,
+        require => Package['collectd']
+    }
+
   }
+
 }

--- a/manifests/service.pp
+++ b/manifests/service.pp
@@ -2,12 +2,10 @@
 class collectd::service {
 
   if $collectd::manage_service {
-
     service { 'collectd':
         ensure  => running,
         require => Package['collectd']
     }
-
   }
 
 }

--- a/manifests/service.pp
+++ b/manifests/service.pp
@@ -1,11 +1,9 @@
 # private
 class collectd::service {
-
   if $collectd::manage_service {
     service { 'collectd':
         ensure  => running,
         require => Package['collectd']
     }
   }
-
 }


### PR DESCRIPTION
Provides a way to bypass the service definition provided by the module.

I opted to just provide a single flag instead of passing through service parameters because the list of valid parameters changes depending on the provider (e.g. some providers don't let you set `enable` to `true`): seemed more straightforward to say, "if you want to customize the service beyond the default provided, define your own."

Ping @jfarrell whenever you get the chance!