### PR TITLE
Fix 'cannot reassign variable' error

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -13,7 +13,6 @@ class collectd::params {
         $log_level              = 'info'
         $loadplugins            = {}
         $ensure_signalfx_plugin_version = present
-        $manage_service            = true
         $dimension_list            = {}
         $signalfx_api_endpoint     = 'https://ingest.signalfx.com/v1/collectd'
         $write_http_timeout        = 3000


### PR DESCRIPTION
Deletes duplicate $manage_service param as a result of poor merging
in pull request #5.